### PR TITLE
Change depedencies to org.eclipse.persistence.jpa

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can find the `sbt-eclipselink-static-weave` plugin on [Maven Central](https:
 1. Add the plugin dependency to your `plugins.sbt`:
 
    ```
-   addSbtPlugin("com.github.atais" % "sbt-eclipselink-static-weave" % "0.1.0")
+   addSbtPlugin("com.github.atais" % "sbt-eclipselink-static-weave" % "0.1.1")
    ```
 
    By default EclipseLink `2.5.1` is used by the plugin to access `StaticWeaveProcessor`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find the `sbt-eclipselink-static-weave` plugin on [Maven Central](https:
    If you would like to override the EclipseLink version, specify it in `plugins.sbt`:
    
    ```
-   libraryDependencies += "org.eclipse.persistence" % "eclipselink" % "<version>"
+   libraryDependencies += "org.eclipse.persistence" % "org.eclipse.persistence.jpa" % "<version>"
    ```
 
 2. Activate the plugin in your project:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import ReleaseTransformations._
 
-lazy val eclipselink = "org.eclipse.persistence" % "eclipselink" % "2.5.1"
+lazy val eclipselink = "org.eclipse.persistence" % "org.eclipse.persistence.jpa" % "2.5.1"
 
 lazy val main = (project in file("."))
   .settings(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
`StaticWeaveProcessor` is in "org.eclipse.persistence" % "org.eclipse.persistence.jpa" % "<version>". For eclipselink "2.7+" this solution prevent the error `https://stackoverflow.com/questions/45870753/eclipselink-2-7-0-and-jpa-api-2-2-0-signature-mismatch`

Solution not tested with eclipselink 2.5.